### PR TITLE
add catalog-info.yaml file for forge catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,32 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: dance-partner
+  title: DancePartner
+  description: DancePartner is a python package which creates multi-omics networks derived from literature and databases
+  annotations:
+    # Conditional host-specific annotations rendered to avoid empty-string values that fail catalog validation.
+    github.com/project-slug: PNNL-Predictive-Phenomics/DancePartner
+  links:
+    - title: DancePartner Repository
+      url: https://github.com/PNNL-Predictive-Phenomics/DancePartner
+    - title: DancePartner Publication
+      url: https://pubmed.ncbi.nlm.nih.gov/41186395/
+  tags:
+    - python
+    - python-library
+    - multi-omics
+    - biomolecule
+    - networks
+spec:
+  type: library
+  owner: user:default/david.degnan_pnnl.gov # David Degnan project contributor
+  visibility: private # to expose this item in the catalog to others at PNNL, change the visibility to 'public'
+  # system: 
+  lifecycle: production
+
+  # TODO: does dance-partner depend on another resource or component?
+  # dependsOn:
+
+  # TODO: does another resource depend on dance-partner? 
+  # dependencyOf:


### PR DESCRIPTION
Add a `catalog-info.yaml` file to root to be ingested in the [Forge Catalog](https://forge.pnnl.gov/catalog). Syncing can take up to an hour for it to populate in the table.

By default, the component will only be visible to the direct owner and Forge admins. If you want this component to be visible to others in the Forge Catalog, please update the visibility field to 'public'

Other attributes can be added/modified as well. Reference to our [user docs](https://forge.pnnl.gov/docs/default/component/forge-user-docs/service-catalog/guidelines/)